### PR TITLE
use the same env variable, fix variable not being set

### DIFF
--- a/components/mintPage/MintPage.js
+++ b/components/mintPage/MintPage.js
@@ -29,8 +29,10 @@ const MintPage = () => {
           setIsLoading(false);
           return response.json();
         })
-        .then((json) => setPolygonUrl(json.transaction_external_url))
-        .then(() => setSuccessStatus(true))
+        .then((json) => {
+          setPolygonUrl(json.transaction_external_url)
+          setSuccessStatus(true)
+        })
         .catch((err) => {
           alert('Something went wrong! Try refreshing the page', err);
           console.error(err);

--- a/contractCalls/mintNft.js
+++ b/contractCalls/mintNft.js
@@ -5,7 +5,7 @@ const mintNft = (fileData, nftName, nftDesc, account) => {
     method: 'POST',
     body: fileData,
     headers: {
-      Authorization: process.env.NFTPORT_KEY,
+      Authorization: process.env.NEXT_PUBLIC_NFTPORT_KEY,
     },
   };
 


### PR DESCRIPTION
polygonUrl wasn't being set. Fixed
We had two different usages for the same env variable. I standardized them.